### PR TITLE
Install cuZFP files

### DIFF
--- a/src/cuZFP/CMakeLists.txt
+++ b/src/cuZFP/CMakeLists.txt
@@ -29,5 +29,5 @@ cuda_add_library(cuZFP
                  ${cuZFP_sources}
                  ${cuZFP_headers})
 
-
-      
+install(TARGETS cuZFP DESTINATION lib64)
+install(FILES cuZFP.h zfp_structs.h DESTINATION include)


### PR DESCRIPTION
cuZFP-specific files are missing from "make install". This patch adds them so that a "make install" will put them next to zfp files.